### PR TITLE
Any reader import fails without MDSplus package

### DIFF
--- a/indica/models/plasma.py
+++ b/indica/models/plasma.py
@@ -19,7 +19,6 @@ from indica.operators.atomic_data import PowerLoss
 import indica.physics as ph
 from indica.profiles_gauss import Profiles
 from indica.readers import ADASReader
-from indica.readers import ST40Reader
 from indica.utilities import assign_data
 from indica.utilities import assign_datatype
 from indica.utilities import print_like
@@ -1304,6 +1303,8 @@ def example_run(
             tstart=tstart, tend=tend, dt=dt / 2, machine_dims=plasma.machine_dimensions
         )
     else:
+        from indica.readers import ST40Reader
+
         reader = ST40Reader(pulse, plasma.tstart - plasma.dt, plasma.tend + plasma.dt)
         equilibrium_data = reader.get("", "efit", 0)
 

--- a/indica/readers/__init__.py
+++ b/indica/readers/__init__.py
@@ -7,7 +7,19 @@ functionality for a different format of data.
 
 from .abstractreader import DataReader
 from .adas import ADASReader
-from .ppfreader import PPFReader
-from .st40reader import ST40Reader
 
-__all__ = ["ADASReader", "DataReader", "PPFReader", "ST40Reader"]
+__all__ = ["ADASReader", "DataReader"]
+
+try:
+    from .ppfreader import PPFReader
+
+    __all__ += ["PPFReader"]
+except ImportError:
+    pass
+
+try:
+    from .st40reader import ST40Reader
+
+    __all__ += ["ST40Reader"]
+except ImportError:
+    pass


### PR DESCRIPTION
Importing any of the reader classes currently fails if you don't have the MDSplus package installed due to importing ST40Reader. MDSplus isn't readily available (e.g. on PyPI) so we shouldn't expect users to have it installed if they're not using a reader that requires it