### PR TITLE
deepcopy cache result

### DIFF
--- a/indica/models/plasma.py
+++ b/indica/models/plasma.py
@@ -1236,7 +1236,7 @@ class CachedCalculation(TrackDependecies):
         print("Recalculating")
         if self.verbose:
             print("Recalculating")
-        return self.operator()
+        return deepcopy(self.operator())
 
 
 def example_run(


### PR DESCRIPTION
Mutable caching results were leading to errors. This has been fixed by returning a deepcopy of the result DataArrays.