### PR TITLE
fixed los length calculation which was including points outside of the separatrix

### DIFF
--- a/indica/converters/abstractconverter.py
+++ b/indica/converters/abstractconverter.py
@@ -451,7 +451,7 @@ class CoordinateTransform(ABC):
             self.impact_rho = rhop_mean.sel(
                 los_position=self.impact_parameter.index.los_position
             )
-            self.los_length = (xr.where(np.isfinite(rhop_mean), 1, 0) * self.dl).sum(
+            self.los_length = (xr.where(rhop_mean <= 1, 1, 0) * self.dl).sum(
                 "los_position"
             )
 


### PR DESCRIPTION
Bad bug making any normalisation to LOS length potentially very wrong...

Affecting Zeff calculation, especially in smaller plasmas where the edge LOS are skimming the plasma. Results for large diverted plasmas remain mainly unaffected.